### PR TITLE
Instana-related otelcol changes for kubernetes deployment

### DIFF
--- a/instana/otelcollector/otelcol-config-extras-k8s.yml
+++ b/instana/otelcollector/otelcol-config-extras-k8s.yml
@@ -1,0 +1,41 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# extra settings to be merged into OpenTelemetry Collector configuration
+# do not delete this file
+
+## Example configuration for sending data to your own OTLP HTTP backend
+## Note: the spanmetrics exporter must be included in the exporters array
+## if overriding the traces pipeline.
+
+opentelemetry-collector:
+  config:
+    processors:
+      resource:
+        attributes:
+          - key: service.instance.id
+            value: otel-demo
+            action: upsert
+
+    # Replace the INSTANA_ENDPOINT, more information:
+    # https://www.ibm.com/docs/en/instana-observability/current?topic=opentelemetry-sending-data-instana
+    exporters:
+      otlp/instana:
+        endpoint: INSTANA_ENDPOINT
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [transform, batch, resource]
+          exporters: [otlp, debug, spanmetrics, otlp/instana]
+        metrics:
+          receivers: [otlp, spanmetrics]
+          processors: [batch, resource]
+          exporters: [otlphttp/prometheus, debug, otlp/instana]
+        logs:
+          receivers: [otlp]
+          processors: [batch, resource]
+          exporters: [opensearch, debug]


### PR DESCRIPTION
I've had issues with deploying Instana opentelemetry demo app with the --values parameter. The error was related to the structure of the original otelcol-extras.yml (which I think works fine for the Docker deployment). For the k8s/k3s based, the structure of the file should be different. Please review the change and merge, if this works fine. Thanks!
